### PR TITLE
feat: Add netlify.toml for deployment configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = ""  # No build command needed for static site
+  publish = "headphonezone/"


### PR DESCRIPTION
Adds a netlify.toml file to specify the 'headphonezone' directory as the publish directory, enabling correct deployment on Netlify for this static site.