### PR TITLE
Fix: Correct Netlify build configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "headphonezone-react"
-  command = "cd headphonezone-react && npm run build"
-  publish = "headphonezone-react/build"
+  command = "npm run build"
+  publish = "build"


### PR DESCRIPTION
The Netlify deploy was failing because the build command was attempting to change into the `headphonezone-react` directory after already being in the base directory set to `headphonezone-react`.

This commit fixes the following in `netlify.toml`:
- Removes the unnecessary `cd headphonezone-react` from the `build.command`.
- Updates the `publish` directory path from `headphonezone-react/build` to `build`, relative to the specified base directory.